### PR TITLE
fix(#157): Add `nowrap` property to team name in banner

### DIFF
--- a/libs/sugaming-ui/src/lib/components/site/create-team-dialog/create-team-dialog.tsx
+++ b/libs/sugaming-ui/src/lib/components/site/create-team-dialog/create-team-dialog.tsx
@@ -113,7 +113,7 @@ export function CreateTeamDialog({ children }: CreateTeamDialogProps) {
             className="flex flex-col w-full h-32 mt-4 overflow-ellipsis justify-center items-center text-center text-white"
             style={{ backgroundColor: form.watch('color') }}
           >
-            <span className="w-fit h-12 px-2 py-1 text-3xl font-bold bg-white text-black dark:bg-black dark:text-white">
+            <span className="w-fit h-12 px-2 py-1 text-3xl font-bold bg-white text-black dark:bg-black dark:text-white whitespace-nowrap">
               {form.watch('name')}
             </span>
             <Logo className="px-4 py-2 scale-50 -mt-3 bg-white text-black dark:bg-black dark:text-white" />


### PR DESCRIPTION
**Before opening a PR**
Please ensure your pull request adheres to the following guidelines:

- [x] Search previous pull requests before making a new one, as yours may be a duplicate.
- [x] Test and validate the new changes you add.
- [x] Add test cases for any new code you introduce.
- [x] Document your newly added changes.
- [x] Add the appropriate labels to your pull request.

**Referenced issue**
This pull request resolves #157.

**Change Description**
Resolved an issue where the name in the team banner was overflowing if it is too long.

**Root Cause (if fixing a bug)**
Missing style properties.

**Breaking change?**
Is the change you are introducing going to affect already other existing resources? (ex. addition of a new required field for an API endpoint may require additional WEB client changes):

- [x] No, this code change does not affect other project resources.
- [ ] Yes, the code changes in this pull request modify already existing project resources.

**Additional context**
![image](https://github.com/fss-fmi/sugaming/assets/26301867/d6affcc7-3e36-4d4a-a8ba-0e344265e525)
